### PR TITLE
✨FEAT: JWT Access/Refresh 토큰 생성 및 Google OAuth 인증 로직 수정

### DIFF
--- a/src/main/java/com/umc7th/a1grade/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/controller/AuthController.java
@@ -1,3 +1,54 @@
 package com.umc7th.a1grade.domain.auth.controller;
 
-public class AuthController {}
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.umc7th.a1grade.domain.auth.exception.status.AuthSuccessStatus;
+import com.umc7th.a1grade.domain.auth.service.OAuth2TokenService;
+import com.umc7th.a1grade.global.apiPayload.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "auth", description = "로그인 및 토큰 관련 API")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+  private final OAuth2TokenService googleTokenService;
+
+  @GetMapping("/google")
+  @Operation(
+      summary = "구글 로그인",
+      description = "구글의 OAuth 인증을 통해 사용자 정보를 처리하고 JWT 토큰을 생성하여 반환합니다.",
+      parameters = {
+        @Parameter(
+            name = "code",
+            description = "구글에서 발급된 인증 코드",
+            required = true,
+            example = "%4adfasdfasgjhdlskkqwtjlk")
+      })
+  public ApiResponse<Map<String, Object>> processGoogleLogin(@RequestParam("code") String code) {
+    Map<String, Object> response = googleTokenService.handleLogin(code);
+    return ApiResponse.of(AuthSuccessStatus._LOGIN_SUCCESS, response);
+  }
+
+  @PostMapping("/logout")
+  @Operation(summary = "로그아웃", description = "사용자 로그아웃 입니다.")
+  public ApiResponse<Object> logout() {
+    return ApiResponse.of(AuthSuccessStatus._LOGOUT_SUCCESS, null);
+  }
+
+  @PostMapping("/token")
+  @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 사용하여 액세스 토큰을 재발급합니다.")
+  public ApiResponse<Object> refreshToken() {
+    return ApiResponse.of(AuthSuccessStatus._TOKEN_REFRESH_SUCCESS, null);
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/controller/AuthController.java
@@ -1,19 +1,27 @@
 package com.umc7th.a1grade.domain.auth.controller;
 
-import java.util.Map;
-
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.umc7th.a1grade.domain.auth.controller.response.LoginResponse;
 import com.umc7th.a1grade.domain.auth.exception.status.AuthSuccessStatus;
+import com.umc7th.a1grade.domain.auth.service.CookieHelper;
 import com.umc7th.a1grade.domain.auth.service.OAuth2TokenService;
 import com.umc7th.a1grade.global.apiPayload.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -23,11 +31,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthController {
   private final OAuth2TokenService googleTokenService;
+  private final CookieHelper cookieHelper;
 
   @GetMapping("/google")
   @Operation(
       summary = "구글 로그인",
-      description = "구글의 OAuth 인증을 통해 사용자 정보를 처리하고 JWT 토큰을 생성하여 반환합니다.",
+      description =
+          "구글 OAuth 인증을 처리하여 사용자 정보를 확인하고 JWT 토큰을 생성하여 반환합니다. \n"
+              + "액세스 토큰은 응답 바디에 포함되며, 리프레시 토큰은 HttpOnly 쿠키에 저장됩니다.",
       parameters = {
         @Parameter(
             name = "code",
@@ -35,20 +46,35 @@ public class AuthController {
             required = true,
             example = "%4adfasdfasgjhdlskkqwtjlk")
       })
-  public ApiResponse<Map<String, Object>> processGoogleLogin(@RequestParam("code") String code) {
-    Map<String, Object> response = googleTokenService.handleLogin(code);
-    return ApiResponse.of(AuthSuccessStatus._LOGIN_SUCCESS, response);
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "로그인에 성공했습니다. JWT 액세스 토큰과 사용자 정보 반환 완료.",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = LoginResponse.class)))
+  })
+  public ResponseEntity<ApiResponse<LoginResponse>> processGoogleLogin(
+      @RequestParam("code") String code) {
+    LoginResponse response = googleTokenService.handleLogin(code);
+    ResponseCookie responseCookie =
+        cookieHelper.createHttpOnlyCookie("refreshToken", response.getRefreshToken());
+
+    return ResponseEntity.ok()
+        .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+        .body(ApiResponse.of(AuthSuccessStatus._LOGIN_SUCCESS, response));
   }
 
   @PostMapping("/logout")
   @Operation(summary = "로그아웃", description = "사용자 로그아웃 입니다.")
-  public ApiResponse<Object> logout() {
+  public ApiResponse logout(@AuthenticationPrincipal UserDetails userDetails) {
     return ApiResponse.of(AuthSuccessStatus._LOGOUT_SUCCESS, null);
   }
 
   @PostMapping("/token")
   @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 사용하여 액세스 토큰을 재발급합니다.")
-  public ApiResponse<Object> refreshToken() {
+  public ApiResponse<Object> refreshToken(@AuthenticationPrincipal UserDetails userDetails) {
     return ApiResponse.of(AuthSuccessStatus._TOKEN_REFRESH_SUCCESS, null);
   }
 }

--- a/src/main/java/com/umc7th/a1grade/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/controller/AuthController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.umc7th.a1grade.domain.auth.controller.response.LoginResponse;
+import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.exception.status.AuthSuccessStatus;
 import com.umc7th.a1grade.domain.auth.service.CookieHelper;
 import com.umc7th.a1grade.domain.auth.service.OAuth2TokenService;

--- a/src/main/java/com/umc7th/a1grade/domain/auth/controller/response/LoginResponse.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/controller/response/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.umc7th.a1grade.domain.auth.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+@Data
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class LoginResponse {
+  private String email;
+  private String accessToken;
+  private String socialId;
+  @JsonIgnore private String refreshToken;
+
+  public LoginResponse(String email, String accessToken, String socialId) {
+    this.email = email;
+    this.accessToken = accessToken;
+    this.socialId = socialId;
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/dto/GoogleTokenResponse.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/dto/GoogleTokenResponse.java
@@ -1,0 +1,30 @@
+package com.umc7th.a1grade.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoogleTokenResponse {
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("expires_in")
+  private int expiresIn;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  @JsonProperty("scope")
+  private String scope;
+
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  @JsonProperty("id_token")
+  private String idToken;
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/dto/LoginResponse.java
@@ -1,7 +1,8 @@
-package com.umc7th.a1grade.domain.auth.controller.response;
+package com.umc7th.a1grade.domain.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +14,7 @@ import lombok.Setter;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title = "LoginResponse - 구글 소셜 로그인 응답 객체")
 public class LoginResponse {
   private String email;
   private String accessToken;

--- a/src/main/java/com/umc7th/a1grade/domain/auth/dto/OAuthAttributes.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/dto/OAuthAttributes.java
@@ -1,0 +1,26 @@
+package com.umc7th.a1grade.domain.auth.dto;
+
+import java.util.Map;
+
+import com.umc7th.a1grade.domain.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuthAttributes {
+  private Map<String, Object> attributes;
+  private String sub;
+  private String email;
+
+  @Builder
+  public OAuthAttributes(Map<String, Object> attributes, String sub, String email) {
+    this.attributes = attributes;
+    this.sub = sub;
+    this.email = email;
+  }
+
+  public User toEntity() {
+    return User.builder().socialId(sub).email(email).build();
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/exception/AuthHandler.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/exception/AuthHandler.java
@@ -1,0 +1,10 @@
+package com.umc7th.a1grade.domain.auth.exception;
+
+import com.umc7th.a1grade.global.apiPayload.code.BaseErrorCode;
+import com.umc7th.a1grade.global.exception.GeneralException;
+
+public class AuthHandler extends GeneralException {
+  public AuthHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthErrorStatus.java
@@ -1,0 +1,42 @@
+package com.umc7th.a1grade.domain.auth.exception.status;
+
+import org.springframework.http.HttpStatus;
+
+import com.umc7th.a1grade.global.apiPayload.code.BaseErrorCode;
+import com.umc7th.a1grade.global.apiPayload.code.ErrorReasonDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorStatus implements BaseErrorCode {
+  _LOGIN_FAIL(HttpStatus.BAD_REQUEST, "AUTH4001", "구글 로그인 처리 중 오류 발생"),
+  _TOKEN_FAIL(HttpStatus.UNAUTHORIZED, "AUTH4002", "구글 액세스 토큰 요청 실패"),
+  _USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "AUTH4003", "구글 사용자 정보 요청 실패"),
+
+  _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4004", "유효하지 않은 토큰입니다."),
+  _TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4005", "토큰이 만료되었습니다."),
+  _REFRESH_TOKEN_REQUIRED(HttpStatus.FORBIDDEN, "AUTH4006", "리프레시 토큰이 필요합니다."),
+
+  _LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5000", "로그아웃 처리 중 오류가 발생했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  @Override
+  public ErrorReasonDTO getReason() {
+    return ErrorReasonDTO.builder().message(message).code(code).isSuccess(false).build();
+  }
+
+  @Override
+  public ErrorReasonDTO getReasonHttpStatus() {
+    return ErrorReasonDTO.builder()
+        .message(message)
+        .code(code)
+        .isSuccess(false)
+        .httpStatus(httpStatus)
+        .build();
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthErrorStatus.java
@@ -19,7 +19,13 @@ public enum AuthErrorStatus implements BaseErrorCode {
   _TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4005", "토큰이 만료되었습니다."),
   _REFRESH_TOKEN_REQUIRED(HttpStatus.FORBIDDEN, "AUTH4006", "리프레시 토큰이 필요합니다."),
 
-  _LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5000", "로그아웃 처리 중 오류가 발생했습니다.");
+  _LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5000", "로그아웃 처리 중 오류가 발생했습니다."),
+
+  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_EXPIRED4001", "JWT 토큰이 만료되었습니다."),
+  UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_UNSUPPORTED4002", "지원되지 않는 JWT 형식입니다."),
+  MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_MALFORMED4003", "JWT 형식이 올바르지 않습니다."),
+  INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "JWT_INVALID_SIGNATURE4004", "JWT 서명이 유효하지 않습니다."),
+  ILLEGAL_ARGUMENT(HttpStatus.UNAUTHORIZED, "JWT_ILLEGAL_ARGUMENT4005", "JWT 토큰 값이 잘못되었습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthSuccessStatus.java
@@ -11,9 +11,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthSuccessStatus implements BaseCode {
-  _OK(HttpStatus.OK, "COMMON2000", "응답에 성공했습니다."),
-  _LOGIN_URL_SUCCESS(HttpStatus.OK, "AUTH2001", "로그인 url 생성에 성공했습니다."),
-  _LOGIN_SUCCESS(HttpStatus.OK, "AUTH2002", "로그인에 성공했습니다."),
+  _LOGIN_SUCCESS(HttpStatus.OK, "AUTH2002", "로그인에 성공했습니다. JWT 액세스 토큰과 사용자 정보 반환 완료."),
   _LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃에 성공했습니다."),
   _TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "AUTH2004", "토큰 재발급에 성공했습니다.");
 

--- a/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/exception/status/AuthSuccessStatus.java
@@ -1,0 +1,38 @@
+package com.umc7th.a1grade.domain.auth.exception.status;
+
+import org.springframework.http.HttpStatus;
+
+import com.umc7th.a1grade.global.apiPayload.code.BaseCode;
+import com.umc7th.a1grade.global.apiPayload.code.ReasonDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthSuccessStatus implements BaseCode {
+  _OK(HttpStatus.OK, "COMMON2000", "응답에 성공했습니다."),
+  _LOGIN_URL_SUCCESS(HttpStatus.OK, "AUTH2001", "로그인 url 생성에 성공했습니다."),
+  _LOGIN_SUCCESS(HttpStatus.OK, "AUTH2002", "로그인에 성공했습니다."),
+  _LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃에 성공했습니다."),
+  _TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "AUTH2004", "토큰 재발급에 성공했습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  @Override
+  public ReasonDTO getReason() {
+    return ReasonDTO.builder().message(message).code(code).isSuccess(false).build();
+  }
+
+  @Override
+  public ReasonDTO getReasonHttpStatus() {
+    return ReasonDTO.builder()
+        .message(message)
+        .code(code)
+        .isSuccess(false)
+        .httpStatus(httpStatus)
+        .build();
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/CookieHelper.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/CookieHelper.java
@@ -1,0 +1,17 @@
+package com.umc7th.a1grade.domain.auth.service;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieHelper {
+  public ResponseCookie createHttpOnlyCookie(String name, String value) {
+    return ResponseCookie.from(name, value)
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .maxAge(7 * 24 * 60 * 60)
+        .sameSite("Strict")
+        .build();
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.umc7th.a1grade.domain.auth.service;
+
+import java.util.List;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.umc7th.a1grade.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    return userRepository
+        .findBySocailId(username)
+        .map(
+            user ->
+                new org.springframework.security.core.userdetails.User(
+                    user.getSocialId(),
+                    "",
+                    List.of(new SimpleGrantedAuthority(user.getRole().name()))))
+        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.umc7th.a1grade.domain.auth.controller.response.LoginResponse;
+import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
 import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
 import com.umc7th.a1grade.domain.auth.exception.AuthHandler;

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
@@ -15,8 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
+import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
 import com.umc7th.a1grade.domain.auth.exception.AuthHandler;
 import com.umc7th.a1grade.domain.auth.exception.status.AuthErrorStatus;

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
@@ -1,0 +1,234 @@
+package com.umc7th.a1grade.domain.auth.service;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
+import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
+import com.umc7th.a1grade.domain.auth.exception.AuthHandler;
+import com.umc7th.a1grade.domain.auth.exception.status.AuthErrorStatus;
+import com.umc7th.a1grade.domain.user.entity.User;
+import com.umc7th.a1grade.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleTokenService implements OAuth2TokenService {
+  private final RestTemplate restTemplate;
+  private final UserRepository userRepository;
+
+  @Value("${spring.security.oauth2.client.registration.google.client-id}")
+  private String clientId;
+
+  @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+  private String clientSecret;
+
+  @Value("${spring.security.oauth2.client.provider.google.token-uri}")
+  private String tokenUri;
+
+  @Value("${spring.security.oauth2.client.provider.google.user-info-uri}")
+  private String userInfoUri;
+
+  @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
+  private String grantType;
+
+  @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+  private String redirectUri;
+
+  @Override
+  @Transactional
+  public Map<String, Object> handleLogin(String code) {
+    String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+    String accessToken = getGoogleToken(decode).getAccessToken();
+    OAuthAttributes attributes = getUserInfo(accessToken);
+
+    User user =
+        userRepository
+            .findBySocailId(attributes.getSub())
+            .orElseGet(() -> userRepository.save(attributes.toEntity()));
+
+    return Map.of(
+        "socialId", user.getSocialId(),
+        "email", user.getEmail());
+  }
+
+  @Transactional
+  public GoogleTokenResponse getGoogleToken(String code) {
+    String tokenUrl =
+        UriComponentsBuilder.fromHttpUrl(tokenUri)
+            .queryParam("grant_type", "authorization_code")
+            .queryParam("client_id", clientId)
+            .queryParam("client_secret", clientSecret)
+            .queryParam("redirect_uri", redirectUri)
+            .queryParam("code", code)package com.umc7th.a1grade.domain.auth.service;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
+import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
+import com.umc7th.a1grade.domain.auth.exception.AuthHandler;
+import com.umc7th.a1grade.domain.auth.exception.status.AuthErrorStatus;
+import com.umc7th.a1grade.domain.user.entity.User;
+import com.umc7th.a1grade.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+    @Slf4j
+    @Service
+    @RequiredArgsConstructor
+    public class GoogleTokenService implements OAuth2TokenService {
+      private final RestTemplate restTemplate;
+      private final UserRepository userRepository;
+
+      @Value("${spring.security.oauth2.client.registration.google.client-id}")
+      private String clientId;
+
+      @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+      private String clientSecret;
+
+      @Value("${spring.security.oauth2.client.provider.google.token-uri}")
+      private String tokenUri;
+
+      @Value("${spring.security.oauth2.client.provider.google.user-info-uri}")
+      private String userInfoUri;
+
+      @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
+      private String grantType;
+
+      @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+      private String redirectUri;
+
+      @Override
+      @Transactional
+      public Map<String, Object> handleLogin(String code) {
+        String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+        String accessToken = getGoogleToken(decode).getAccessToken();
+        OAuthAttributes attributes = getUserInfo(accessToken);
+
+        User user =
+            userRepository
+                .findBySocailId(attributes.getSub())
+                .orElseGet(() -> userRepository.save(attributes.toEntity()));
+
+        return Map.of(
+            "socialId", user.getSocialId(),
+            "email", user.getEmail());
+      }
+
+      @Transactional
+      public GoogleTokenResponse getGoogleToken(String code) {
+        String tokenUrl =
+            UriComponentsBuilder.fromHttpUrl(tokenUri)
+                .queryParam("grant_type", "authorization_code")
+                .queryParam("client_id", clientId)
+                .queryParam("client_secret", clientSecret)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("code", code)
+                .build()
+                .toUriString();
+
+        try {
+          ResponseEntity<GoogleTokenResponse> response =
+              restTemplate.exchange(tokenUrl, HttpMethod.POST, null, GoogleTokenResponse.class);
+          log.info("구글 엑세스 토큰 응답: {}", response.getBody().getAccessToken());
+          return response.getBody();
+        } catch (Exception e) {
+          log.error("구글 엑세스 토큰 요청 실패 : {}", e.getMessage(), e);
+          throw new AuthHandler(AuthErrorStatus._TOKEN_FAIL);
+        }
+      }
+
+      @Override
+      @Transactional
+      public OAuthAttributes getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        ResponseEntity<Map<String, Object>> response;
+        try {
+          response =
+              restTemplate.exchange(
+                  userInfoUri, HttpMethod.GET, request, new ParameterizedTypeReference<>() {});
+
+        } catch (Exception e) {
+          throw new AuthHandler(AuthErrorStatus._USER_INFO_FAIL);
+        }
+        Map<String, Object> attributes = response.getBody();
+
+        return OAuthAttributes.builder()
+            .attributes(attributes)
+            .email((String) attributes.get("email"))
+            .sub((String) attributes.get("sub"))
+            .build();
+      }
+    }
+
+            .build()
+            .toUriString();
+
+    try {
+      ResponseEntity<GoogleTokenResponse> response =
+          restTemplate.exchange(tokenUrl, HttpMethod.POST, null, GoogleTokenResponse.class);
+      log.info("구글 엑세스 토큰 응답: {}", response.getBody().getAccessToken());
+      return response.getBody();
+    } catch (Exception e) {
+      log.error("구글 엑세스 토큰 요청 실패 : {}", e.getMessage(), e);
+      throw new AuthHandler(AuthErrorStatus._TOKEN_FAIL);
+    }
+  }
+
+  @Override
+  @Transactional
+  public OAuthAttributes getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+
+    HttpEntity<String> request = new HttpEntity<>(headers);
+    ResponseEntity<Map<String, Object>> response;
+    try {
+      response =
+          restTemplate.exchange(
+              userInfoUri, HttpMethod.GET, request, new ParameterizedTypeReference<>() {});
+
+    } catch (Exception e) {
+      throw new AuthHandler(AuthErrorStatus._USER_INFO_FAIL);
+    }
+    Map<String, Object> attributes = response.getBody();
+
+    return OAuthAttributes.builder()
+        .attributes(attributes)
+        .email((String) attributes.get("email"))
+        .sub((String) attributes.get("sub"))
+        .build();
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/GoogleTokenService.java
@@ -15,10 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.umc7th.a1grade.domain.auth.controller.response.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
 import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
 import com.umc7th.a1grade.domain.auth.exception.AuthHandler;
 import com.umc7th.a1grade.domain.auth.exception.status.AuthErrorStatus;
+import com.umc7th.a1grade.domain.jwt.JwtProvider;
+import com.umc7th.a1grade.domain.user.entity.Role;
 import com.umc7th.a1grade.domain.user.entity.User;
 import com.umc7th.a1grade.domain.user.repository.UserRepository;
 
@@ -29,8 +32,10 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class GoogleTokenService implements OAuth2TokenService {
+
   private final RestTemplate restTemplate;
   private final UserRepository userRepository;
+  private final JwtProvider jwtProvider;
 
   @Value("${spring.security.oauth2.client.registration.google.client-id}")
   private String clientId;
@@ -52,147 +57,39 @@ public class GoogleTokenService implements OAuth2TokenService {
 
   @Override
   @Transactional
-  public Map<String, Object> handleLogin(String code) {
+  public LoginResponse handleLogin(String code) {
     String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
-    String accessToken = getGoogleToken(decode).getAccessToken();
+    String accessToken = getAccessToken(decode).getAccessToken();
     OAuthAttributes attributes = getUserInfo(accessToken);
-
     User user =
         userRepository
             .findBySocailId(attributes.getSub())
-            .orElseGet(() -> userRepository.save(attributes.toEntity()));
+            .orElseGet(
+                () -> {
+                  User newUser = attributes.toEntity();
+                  newUser.setRole(Role.ROLE_USER);
+                  return userRepository.save(newUser);
+                });
 
-    return Map.of(
-        "socialId", user.getSocialId(),
-        "email", user.getEmail());
+    String jwtAccessToken = jwtProvider.createAccessToken(user.getSocialId());
+    String jwtRefreshToken = jwtProvider.createRefreshToken();
+    user.setRefreshToken(jwtRefreshToken);
+
+    log.info("JWT 액세스 토큰 생성: {}", jwtAccessToken);
+    log.info("JWT 리프레시 토큰 생성: {}", jwtRefreshToken);
+
+    return new LoginResponse(user.getEmail(), jwtAccessToken, user.getSocialId(), jwtRefreshToken);
   }
 
   @Transactional
-  public GoogleTokenResponse getGoogleToken(String code) {
+  public GoogleTokenResponse getAccessToken(String code) {
     String tokenUrl =
         UriComponentsBuilder.fromHttpUrl(tokenUri)
-            .queryParam("grant_type", "authorization_code")
+            .queryParam("grant_type", grantType)
             .queryParam("client_id", clientId)
             .queryParam("client_secret", clientSecret)
             .queryParam("redirect_uri", redirectUri)
-            .queryParam("code", code)package com.umc7th.a1grade.domain.auth.service;
-
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
-import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
-import com.umc7th.a1grade.domain.auth.exception.AuthHandler;
-import com.umc7th.a1grade.domain.auth.exception.status.AuthErrorStatus;
-import com.umc7th.a1grade.domain.user.entity.User;
-import com.umc7th.a1grade.domain.user.repository.UserRepository;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-    @Slf4j
-    @Service
-    @RequiredArgsConstructor
-    public class GoogleTokenService implements OAuth2TokenService {
-      private final RestTemplate restTemplate;
-      private final UserRepository userRepository;
-
-      @Value("${spring.security.oauth2.client.registration.google.client-id}")
-      private String clientId;
-
-      @Value("${spring.security.oauth2.client.registration.google.client-secret}")
-      private String clientSecret;
-
-      @Value("${spring.security.oauth2.client.provider.google.token-uri}")
-      private String tokenUri;
-
-      @Value("${spring.security.oauth2.client.provider.google.user-info-uri}")
-      private String userInfoUri;
-
-      @Value("${spring.security.oauth2.client.registration.google.authorization-grant-type}")
-      private String grantType;
-
-      @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
-      private String redirectUri;
-
-      @Override
-      @Transactional
-      public Map<String, Object> handleLogin(String code) {
-        String decode = URLDecoder.decode(code, StandardCharsets.UTF_8);
-        String accessToken = getGoogleToken(decode).getAccessToken();
-        OAuthAttributes attributes = getUserInfo(accessToken);
-
-        User user =
-            userRepository
-                .findBySocailId(attributes.getSub())
-                .orElseGet(() -> userRepository.save(attributes.toEntity()));
-
-        return Map.of(
-            "socialId", user.getSocialId(),
-            "email", user.getEmail());
-      }
-
-      @Transactional
-      public GoogleTokenResponse getGoogleToken(String code) {
-        String tokenUrl =
-            UriComponentsBuilder.fromHttpUrl(tokenUri)
-                .queryParam("grant_type", "authorization_code")
-                .queryParam("client_id", clientId)
-                .queryParam("client_secret", clientSecret)
-                .queryParam("redirect_uri", redirectUri)
-                .queryParam("code", code)
-                .build()
-                .toUriString();
-
-        try {
-          ResponseEntity<GoogleTokenResponse> response =
-              restTemplate.exchange(tokenUrl, HttpMethod.POST, null, GoogleTokenResponse.class);
-          log.info("구글 엑세스 토큰 응답: {}", response.getBody().getAccessToken());
-          return response.getBody();
-        } catch (Exception e) {
-          log.error("구글 엑세스 토큰 요청 실패 : {}", e.getMessage(), e);
-          throw new AuthHandler(AuthErrorStatus._TOKEN_FAIL);
-        }
-      }
-
-      @Override
-      @Transactional
-      public OAuthAttributes getUserInfo(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
-
-        HttpEntity<String> request = new HttpEntity<>(headers);
-        ResponseEntity<Map<String, Object>> response;
-        try {
-          response =
-              restTemplate.exchange(
-                  userInfoUri, HttpMethod.GET, request, new ParameterizedTypeReference<>() {});
-
-        } catch (Exception e) {
-          throw new AuthHandler(AuthErrorStatus._USER_INFO_FAIL);
-        }
-        Map<String, Object> attributes = response.getBody();
-
-        return OAuthAttributes.builder()
-            .attributes(attributes)
-            .email((String) attributes.get("email"))
-            .sub((String) attributes.get("sub"))
-            .build();
-      }
-    }
-
+            .queryParam("code", code)
             .build()
             .toUriString();
 

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
@@ -1,7 +1,7 @@
 package com.umc7th.a1grade.domain.auth.service;
 
-import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
+import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
 
 public interface OAuth2TokenService {

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
@@ -1,14 +1,13 @@
 package com.umc7th.a1grade.domain.auth.service;
 
-import java.util.Map;
-
+import com.umc7th.a1grade.domain.auth.controller.response.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
 import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
 
 public interface OAuth2TokenService {
-  GoogleTokenResponse getGoogleToken(String code);
+  GoogleTokenResponse getAccessToken(String code);
 
   OAuthAttributes getUserInfo(String accessToken);
 
-  Map<String, Object> handleLogin(String code);
+  LoginResponse handleLogin(String code);
 }

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
@@ -1,0 +1,14 @@
+package com.umc7th.a1grade.domain.auth.service;
+
+import java.util.Map;
+
+import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
+import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
+
+public interface OAuth2TokenService {
+  GoogleTokenResponse getGoogleToken(String code);
+
+  OAuthAttributes getUserInfo(String accessToken);
+
+  Map<String, Object> handleLogin(String code);
+}

--- a/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/auth/service/OAuth2TokenService.java
@@ -1,6 +1,6 @@
 package com.umc7th.a1grade.domain.auth.service;
 
-import com.umc7th.a1grade.domain.auth.controller.response.LoginResponse;
+import com.umc7th.a1grade.domain.auth.dto.LoginResponse;
 import com.umc7th.a1grade.domain.auth.dto.GoogleTokenResponse;
 import com.umc7th.a1grade.domain.auth.dto.OAuthAttributes;
 

--- a/src/main/java/com/umc7th/a1grade/domain/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc7th/a1grade/domain/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,38 @@
+package com.umc7th.a1grade.domain.jwt;
+
+import java.io.IOException;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc7th.a1grade.global.apiPayload.ApiResponse;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException, ServletException {
+
+    ApiResponse<Object> apiResponse =
+        ApiResponse.onFailure("AUTH401", "Unauthorized: 인증이 필요합니다.", null);
+
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.getWriter().write(convertObjectToJson(apiResponse));
+  }
+
+  private String convertObjectToJson(Object object) throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.writeValueAsString(object);
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/jwt/JwtFilter.java
+++ b/src/main/java/com/umc7th/a1grade/domain/jwt/JwtFilter.java
@@ -1,0 +1,64 @@
+package com.umc7th.a1grade.domain.jwt;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private final JwtProvider jwtProvider;
+  private final UserDetailsService userDetailsService;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    try {
+      String token = resolveToken(request);
+      if (token != null && jwtProvider.validateToken(token)) {
+        String socialId = jwtProvider.extractSocialId(token);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(socialId);
+
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        log.debug("SecurityContext에 '{}' 인증 정보를 저장했습니다.", socialId);
+      }
+    } catch (JwtException | IllegalArgumentException e) {
+      log.error("JWT 검증 실패 : {}", e.getMessage());
+      SecurityContextHolder.clearContext();
+      throw new AuthenticationServiceException("JWT 인증 실패", e);
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+    if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+      return bearerToken.substring(BEARER_PREFIX.length());
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/jwt/JwtProvider.java
+++ b/src/main/java/com/umc7th/a1grade/domain/jwt/JwtProvider.java
@@ -1,0 +1,77 @@
+package com.umc7th.a1grade.domain.jwt;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.umc7th.a1grade.domain.auth.exception.AuthHandler;
+import com.umc7th.a1grade.domain.auth.exception.status.AuthErrorStatus;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtProvider {
+  private final Key key;
+  private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;
+
+  public JwtProvider(@Value("${spring.jwt.secret}") String secretKey) {
+    byte[] keyBytes = java.util.Base64.getDecoder().decode(secretKey);
+    this.key = Keys.hmacShaKeyFor(keyBytes);
+  }
+
+  public String createAccessToken(String socialId) {
+    Date now = new Date();
+    return Jwts.builder()
+        .setSubject(socialId)
+        .setId(String.valueOf(socialId))
+        .setIssuedAt(new Date())
+        .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_TIME))
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public String createRefreshToken() {
+    Date now = new Date();
+    return Jwts.builder()
+        .setIssuedAt(now)
+        .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME))
+        .signWith(key, SignatureAlgorithm.HS256)
+        .compact();
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+      return true;
+    } catch (ExpiredJwtException e) {
+      throw new AuthHandler(AuthErrorStatus.EXPIRED_TOKEN);
+    } catch (UnsupportedJwtException e) {
+      throw new AuthHandler(AuthErrorStatus.UNSUPPORTED_TOKEN);
+    } catch (MalformedJwtException e) {
+      throw new AuthHandler(AuthErrorStatus.MALFORMED_TOKEN);
+    } catch (io.jsonwebtoken.SignatureException e) {
+      throw new AuthHandler(AuthErrorStatus.INVALID_SIGNATURE);
+    } catch (IllegalArgumentException e) {
+      throw new AuthHandler(AuthErrorStatus.ILLEGAL_ARGUMENT);
+    }
+  }
+
+  public String extractSocialId(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject();
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/jwt/JwtUtil.java
+++ b/src/main/java/com/umc7th/a1grade/domain/jwt/JwtUtil.java
@@ -1,3 +1,0 @@
-package com.umc7th.a1grade.domain.jwt;
-
-public class JwtUtil {}

--- a/src/main/java/com/umc7th/a1grade/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/controller/UserController.java
@@ -1,3 +1,45 @@
 package com.umc7th.a1grade.domain.user.controller;
 
-public class UserController {}
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.umc7th.a1grade.domain.user.dto.UserInfoDto;
+import com.umc7th.a1grade.global.apiPayload.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "user", description = "회원 관리 API")
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+  @Operation(
+      summary = "닉네임 중복 확인",
+      description = "사용자가 입력한 닉네임이 이미 존재하는지 확인합니다.",
+      parameters = {
+        @Parameter(
+            name = "nickname",
+            description = "중복 확인을 요청할 닉네임",
+            required = true,
+            example = "testUser")
+      })
+  @GetMapping("/nickname/check")
+  public ApiResponse<Boolean> confirmNickName(@RequestParam("nickname") String nickname) {
+    return ApiResponse.onSuccess(true);
+  }
+
+  @Operation(summary = "닉네임 저장", description = "사용자에게 입력받은 닉네임을 저장합니다.")
+  @PostMapping("/nickname/save")
+  public ApiResponse<Boolean> saveNickame(@RequestBody @Valid UserInfoDto request) {
+    return ApiResponse.onSuccess(true);
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/controller/UserController.java
@@ -2,6 +2,8 @@ package com.umc7th.a1grade.domain.user.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,13 +35,15 @@ public class UserController {
             example = "testUser")
       })
   @GetMapping("/nickname/check")
-  public ApiResponse<Boolean> confirmNickName(@RequestParam("nickname") String nickname) {
+  public ApiResponse<Boolean> confirmNickName(
+      @AuthenticationPrincipal UserDetails userDetails, @RequestParam("nickname") String nickname) {
     return ApiResponse.onSuccess(true);
   }
 
   @Operation(summary = "닉네임 저장", description = "사용자에게 입력받은 닉네임을 저장합니다.")
   @PostMapping("/nickname/save")
-  public ApiResponse<Boolean> saveNickame(@RequestBody @Valid UserInfoDto request) {
+  public ApiResponse<Boolean> saveNickame(
+      @AuthenticationPrincipal UserDetails userDetails, @RequestBody @Valid UserInfoDto request) {
     return ApiResponse.onSuccess(true);
   }
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/dto/Response.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/dto/Response.java
@@ -1,3 +1,0 @@
-package com.umc7th.a1grade.domain.user.dto;
-
-public class Response {}

--- a/src/main/java/com/umc7th/a1grade/domain/user/dto/UserInfoDto.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/dto/UserInfoDto.java
@@ -1,0 +1,21 @@
+package com.umc7th.a1grade.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoDto {
+  @NotBlank(message = "닉네임은 필수 입력 항목입니다. 최대 5자 까지 입력 가능")
+  @Size(max = 5)
+  @Schema(description = "닉네임", example = "홍길동", type = "string")
+  private String nickname;
+}

--- a/src/main/java/com/umc7th/a1grade/domain/user/dto/UserInfoDto.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/dto/UserInfoDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(title = "UserInfoDto - 닉네임 입력을 위한 데이터 전송 객체")
 public class UserInfoDto {
   @NotBlank(message = "닉네임은 필수 입력 항목입니다. 최대 5자 까지 입력 가능")
   @Size(max = 5)

--- a/src/main/java/com/umc7th/a1grade/domain/user/entity/User.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 import com.umc7th.a1grade.global.common.BaseTimeEntity;
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(name = "users")
 public class User extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,8 +38,12 @@ public class User extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   private Role role;
 
+  private String nickName;
+
+  private Long imageId;
+
+  // 필요한 항목들인지 확인 해야함
   private String birth;
   private String region;
   private String phone;
-  private String nickName;
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/entity/User.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/entity/User.java
@@ -33,6 +33,7 @@ public class User extends BaseTimeEntity {
   private SocialType socialType;
 
   @NotNull private String socialId;
+
   @NotNull private String email;
 
   @Enumerated(EnumType.STRING)
@@ -42,8 +43,18 @@ public class User extends BaseTimeEntity {
 
   private Long imageId;
 
+  private String refreshToken;
+
   // 필요한 항목들인지 확인 해야함
   private String birth;
   private String region;
   private String phone;
+
+  public void setRefreshToken(String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
+
+  public void setRole(Role role) {
+    this.role = role;
+  }
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
@@ -1,0 +1,13 @@
+package com.umc7th.a1grade.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.umc7th.a1grade.domain.user.entity.User;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+  Optional<User> findByNickName(String nickname);
+
+  Optional<User> findBySocialId(String socialId);
+}

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepository.java
@@ -1,3 +1,13 @@
 package com.umc7th.a1grade.domain.user.repository;
 
-public interface UserRepository {}
+import java.util.Optional;
+
+import com.umc7th.a1grade.domain.user.entity.User;
+
+public interface UserRepository {
+  Optional<User> findByNickname(String nickname);
+
+  Optional<User> findBySocailId(String socialId);
+
+  User save(User user);
+}

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.umc7th.a1grade.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.umc7th.a1grade.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+  private final UserJpaRepository userJpaRepository;
+
+  @Override
+  public Optional<User> findByNickname(String nickname) {
+    return userJpaRepository.findByNickName(nickname);
+  }
+
+  @Override
+  public Optional<User> findBySocailId(String socialId) {
+    return userJpaRepository.findBySocialId(socialId);
+  }
+
+  @Override
+  public User save(User user) {
+    return userJpaRepository.save(user);
+  }
+}

--- a/src/main/java/com/umc7th/a1grade/domain/user/service/UserService.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/service/UserService.java
@@ -1,3 +1,3 @@
 package com.umc7th.a1grade.domain.user.service;
 
-public class UserService {}
+public interface UserService {}

--- a/src/main/java/com/umc7th/a1grade/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,14 @@
+package com.umc7th.a1grade.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import com.umc7th.a1grade.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+}

--- a/src/main/java/com/umc7th/a1grade/global/config/CorsConfig.java
+++ b/src/main/java/com/umc7th/a1grade/global/config/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig {
     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
     configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Accept"));
     configuration.setAllowCredentials(true);
-    configuration.setExposedHeaders(Arrays.asList("Authorization", "Refresh-Token"));
+    configuration.setExposedHeaders(Arrays.asList("Authorization"));
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     return source;

--- a/src/main/java/com/umc7th/a1grade/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/umc7th/a1grade/global/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.umc7th.a1grade.global.config;
+
+import java.nio.charset.Charset;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+  @Bean
+  public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+    return restTemplateBuilder
+        .requestFactory(
+            () -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+        .additionalMessageConverters(new StringHttpMessageConverter(Charset.forName("UTF-8")))
+        .build();
+  }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #7 

## 📌 작업 내용 및 특이사항
1. JWT Access/Refresh 토큰 생성 및 검증 기능 추가하였습니다. 
2. 구글 로그인 시 Access Token은 ResponseBody에, Refresh Token은 HttpOnly Cookie로 전달하였습니다.
3. Swagger 명세에 구글 로그인 API 요청/응답 구조를 작성하였습니다.

### 주요 변경 사항
- `JwtProvider`: JWT 토큰 생성 및 검증 로직을 추가하였습니다.
- `JwtFilter`: HttpServletRequest에서 토큰을 추출하고 검증 후 SecurityContext 설정하였습니다.
- `CustomUserDetailsService`: 사용자 인증 로직 구현하였습니다.
- Refresh Token은 현재 member 테이블에 저장합니다. 

## 📝 참고사항
- Refresh Token은 현재 member 테이블에 저장합니다.

## ✅ 테스트
- Google OAuth 인증 후 JWT Access/Refresh 토큰 발급 확인을 확인하였습니다.
- Swagger UI를 통한 API 요청 및 응답이 정상적으로 작동하는지 확인 완료하였습니다.