### PR TITLE
♻️ Refactor : 1등급 경쟁 랭킹 조회 API 예외처리

### DIFF
--- a/src/main/java/com/umc7th/a1grade/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/exception/status/UserErrorStatus.java
@@ -21,8 +21,10 @@ public enum UserErrorStatus implements BaseErrorCode {
   _USER_INFO_INVALID(HttpStatus.BAD_REQUEST, "CHAR4005", "존재하지 않은 캐릭터 아이디 입니다."),
   _USER_CREDIT_ZERO(HttpStatus.BAD_REQUEST, "CREDIT4003", "사용자의 크레딧이 부족합니다."),
 
-  _USER_REDIS_CONNECTION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS5001", "Redis 서버에 연결할 수 없습니다."),
-  _USER_REDIS_ACCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS5002", "Redis 데이터 접근 중 오류가 발생했습니다."),
+  _USER_REDIS_CONNECTION_FAIL(
+      HttpStatus.INTERNAL_SERVER_ERROR, "REDIS5001", "Redis 서버에 연결할 수 없습니다."),
+  _USER_REDIS_ACCESS_ERROR(
+      HttpStatus.INTERNAL_SERVER_ERROR, "REDIS5002", "Redis 데이터 접근 중 오류가 발생했습니다."),
   _USER_JSON_PARSE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "JSON5003", "JSON 데이터 변환에 실패했습니다."),
   _USER_TOP3_NOT_FOUND(HttpStatus.NOT_FOUND, "TOP3_4006", "상위 3명에 대한 데이터가 없습니다.");
 

--- a/src/main/java/com/umc7th/a1grade/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/exception/status/UserErrorStatus.java
@@ -19,7 +19,12 @@ public enum UserErrorStatus implements BaseErrorCode {
 
   _USER_EMAIL_EXIST(HttpStatus.BAD_REQUEST, "EMAIL4004", "이미 가입되어 있는 이메일입니다."),
   _USER_INFO_INVALID(HttpStatus.BAD_REQUEST, "CHAR4005", "존재하지 않은 캐릭터 아이디 입니다."),
-  _USER_CREDIT_ZERO(HttpStatus.BAD_REQUEST, "CREDIT4003", "사용자의 크레딧이 부족합니다.");
+  _USER_CREDIT_ZERO(HttpStatus.BAD_REQUEST, "CREDIT4003", "사용자의 크레딧이 부족합니다."),
+
+  _USER_REDIS_CONNECTION_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS5001", "Redis 서버에 연결할 수 없습니다."),
+  _USER_REDIS_ACCESS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "REDIS5002", "Redis 데이터 접근 중 오류가 발생했습니다."),
+  _USER_JSON_PARSE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "JSON5003", "JSON 데이터 변환에 실패했습니다."),
+  _USER_TOP3_NOT_FOUND(HttpStatus.NOT_FOUND, "TOP3_4006", "상위 3명에 대한 데이터가 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
@@ -32,6 +32,6 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
           + "    FROM QuestionLog ql "
           + "    WHERE ql.isCorrect = true "
           + "    GROUP BY ql.user.id "
-          + "    HAVING COUNT(DISTINCT ql.userQuestion.id) >= 50)")
+          + "    HAVING COUNT(DISTINCT ql.userQuestion.id) >= 10)")
   List<User> findUserWithCorrectAnswers();
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/service/UserServiceImpl.java
@@ -2,7 +2,10 @@ package com.umc7th.a1grade.domain.user.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -23,6 +26,7 @@ import com.umc7th.a1grade.global.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.StringUtils;
 
 @Service
 @Slf4j
@@ -72,16 +76,27 @@ public class UserServiceImpl implements UserService {
 
     for (int i = 1; i <= 3; i++) {
       String rankKey = "RANK:" + i;
-      String rankingJson = redisTemplate.opsForValue().get(rankKey);
-
-      if (rankingJson != null) {
-        try {
-          AllGradeResponseDto dto = objectMapper.readValue(rankingJson, AllGradeResponseDto.class);
-          top3Users.add(dto);
-        } catch (JsonProcessingException e) {
-          log.info("JSON 변환 오류: " + e.getMessage());
+      try {
+        String rankingJson = redisTemplate.opsForValue().get(rankKey);
+        if (!StringUtils.hasText(rankingJson)) {
+          log.info("순위{}에 해당하는 데이터 없음", i);
+          continue;
         }
+        top3Users.add(objectMapper.readValue(rankingJson, AllGradeResponseDto.class));
+      } catch (JsonProcessingException e) {
+        log.error("순위 {} 데이터 JSON 변환 실패: {}", i, e.getMessage());
+        throw new UserHandler(UserErrorStatus._USER_JSON_PARSE_FAIL);
+      } catch (RedisConnectionFailureException e) {
+        log.error("Redis 서버 연결 실패: {}", e.getMessage());
+        throw new UserHandler(UserErrorStatus._USER_REDIS_CONNECTION_FAIL);
+      } catch (DataAccessException e) {
+        log.error("Redis 데이터 접근 오류 발생: {}", e.getMessage());
+        throw new UserHandler(UserErrorStatus._USER_REDIS_ACCESS_ERROR);
       }
+    }
+    if (top3Users.isEmpty()) {
+      log.warn("상위 3명에 대한 데이터가 없습니다.");
+      throw new UserHandler(UserErrorStatus._USER_TOP3_NOT_FOUND);
     }
     return top3Users;
   }

--- a/src/main/java/com/umc7th/a1grade/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/service/UserServiceImpl.java
@@ -2,7 +2,6 @@ package com.umc7th.a1grade.domain.user.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.RedisConnectionFailureException;
@@ -10,6 +9,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +26,6 @@ import com.umc7th.a1grade.global.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.util.StringUtils;
 
 @Service
 @Slf4j


### PR DESCRIPTION
## 🌱 관련 이슈
- close #80 

## 📌 작업 내용 및 특이사항

1.  랭킹 조회 시 상위 3위 내 데이터가 없는 경우 예외 처리를 추가하였습니다.  
2.  Redis 관련 예외 처리를 추가하였습니다.

>  redis 연결 실패
>  redis 데이터 접근 실패
>  데이터 JSON 변환 실패 

3.  기존에는 정답 또는 오답 개수가 50개 이상인 사용자만 랭킹에 포함되었으나, 테스트 편의를 위해 기준을 10개로 조정하였습니다. (  이 부분은 기획자와 협의 후 진행하였습니다.   )