### PR TITLE
♻️ Refactor : 랭킹 계산 시 유저 조회 방식 변경 

### DIFF
--- a/src/main/java/com/umc7th/a1grade/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/ranking/service/RankingServiceImpl.java
@@ -44,7 +44,7 @@ public class RankingServiceImpl implements RankingService {
     LocalDateTime start = LocalDate.now().minusDays(1).atStartOfDay();
     LocalDateTime end = LocalDate.now().atStartOfDay();
 
-    List<User> users = getUsersWithEnoughCorrectAnswers();
+    List<User> users = getUsers(start, end);
 
     List<UserRankingDto> top3Users =
         users.stream()
@@ -99,8 +99,8 @@ public class RankingServiceImpl implements RankingService {
     return Duration.between(now, night);
   }
 
-  private List<User> getUsersWithEnoughCorrectAnswers() {
-    return userRepository.findUserWithCorrectAnswers();
+  private List<User> getUsers(LocalDateTime start, LocalDateTime end) {
+    return userRepository.findUsersWhoSolvedQuestions(start, end);
   }
 
   private UserRankingDto calculateUserRanking(User user, LocalDateTime start, LocalDateTime end) {

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
@@ -1,5 +1,6 @@
 package com.umc7th.a1grade.domain.user.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,4 +35,11 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
           + "    GROUP BY ql.user.id "
           + "    HAVING COUNT(DISTINCT ql.userQuestion.id) >= 10)")
   List<User> findUserWithCorrectAnswers();
+
+  @Query(
+      "SELECT DISTINCT ql.user FROM QuestionLog ql "
+          + "WHERE ql.submissionTime "
+          + "BETWEEN :start AND :end")
+  List<User> findUsersWhoSolvedQuestions(
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.umc7th.a1grade.domain.user.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,4 +18,8 @@ public interface UserRepository {
   Long countCorrectAnswerByUserId(Long userId);
 
   List<User> findUserWithCorrectAnswers();
+
+  List<User> findAll();
+
+  List<User> findUsersWhoSolvedQuestions(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.umc7th.a1grade.domain.user.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,5 +43,15 @@ public class UserRepositoryImpl implements UserRepository {
   @Override
   public List<User> findUserWithCorrectAnswers() {
     return userJpaRepository.findUserWithCorrectAnswers();
+  }
+
+  @Override
+  public List<User> findAll() {
+    return userJpaRepository.findAll();
+  }
+
+  @Override
+  public List<User> findUsersWhoSolvedQuestions(LocalDateTime start, LocalDateTime end) {
+    return userJpaRepository.findUsersWhoSolvedQuestions(start, end);
   }
 }

--- a/src/test/java/com/umc7th/a1grade/unittest/user/fake/FakeUserRepository.java
+++ b/src/test/java/com/umc7th/a1grade/unittest/user/fake/FakeUserRepository.java
@@ -1,5 +1,6 @@
 package com.umc7th.a1grade.unittest.user.fake;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -63,6 +64,11 @@ public class FakeUserRepository implements UserRepository {
 
   public List<User> findAll() {
     return new ArrayList<>(data);
+  }
+
+  @Override
+  public List<User> findUsersWhoSolvedQuestions(LocalDateTime start, LocalDateTime end) {
+    return null;
   }
 
   public void clear() {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #85 

## 📌 작업 내용 및 특이사항
- 기존: 정답 개수가 10개 이상인 유저만 조회 후, 조회된 유저들을 대상으로 1,2,3순위를 결정
- 변경: 어제 문제를 푼 모든 유저를 조회 후, 조회된 유저들을 대상으로 1,2,3순위를 결정
