### PR TITLE
🐛 Fix : LazyInitializationException 해결 및 Redis 저장 트랜잭션 처리

### DIFF
--- a/src/main/java/com/umc7th/a1grade/domain/question/repository/QuestionLogRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/question/repository/QuestionLogRepository.java
@@ -43,5 +43,7 @@ public interface QuestionLogRepository extends JpaRepository<QuestionLog, Long> 
           + "FROM QuestionLog ql "
           + "WHERE ql.user.id = :userId "
           + "AND ql.submissionTime BETWEEN :start AND :end")
-  long countTotalAttempts(Long userId, LocalDateTime start, LocalDateTime end);
+  long countTotalAttempts(@Param("userId") Long userId,
+                          @Param("start") LocalDateTime start,
+                          @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/umc7th/a1grade/domain/question/repository/QuestionLogRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/question/repository/QuestionLogRepository.java
@@ -43,7 +43,8 @@ public interface QuestionLogRepository extends JpaRepository<QuestionLog, Long> 
           + "FROM QuestionLog ql "
           + "WHERE ql.user.id = :userId "
           + "AND ql.submissionTime BETWEEN :start AND :end")
-  long countTotalAttempts(@Param("userId") Long userId,
-                          @Param("start") LocalDateTime start,
-                          @Param("end") LocalDateTime end);
+  long countTotalAttempts(
+      @Param("userId") Long userId,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/umc7th/a1grade/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/ranking/service/RankingServiceImpl.java
@@ -33,6 +33,7 @@ public class RankingServiceImpl implements RankingService {
   private final ObjectMapper objectMapper;
 
   @Scheduled(cron = "0 0 0 * * ?")
+//  @Scheduled(cron = "0 */1 * * * ?")
   public void scheduleDailyRankingUpdate() {
     log.info("갱신 실행");
     updateDailyRanking();
@@ -59,7 +60,8 @@ public class RankingServiceImpl implements RankingService {
     saveRankingToRedis(top3Users);
   }
 
-  private void saveRankingToRedis(List<UserRankingDto> top3Users) {
+  @Transactional
+  public void saveRankingToRedis(List<UserRankingDto> top3Users) {
     Duration ttl = getRemainingTime();
 
     for (int i = 0; i < top3Users.size(); i++) {

--- a/src/main/java/com/umc7th/a1grade/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/umc7th/a1grade/domain/ranking/service/RankingServiceImpl.java
@@ -33,7 +33,7 @@ public class RankingServiceImpl implements RankingService {
   private final ObjectMapper objectMapper;
 
   @Scheduled(cron = "0 0 0 * * ?")
-//  @Scheduled(cron = "0 */1 * * * ?")
+  //  @Scheduled(cron = "0 */1 * * * ?")
   public void scheduleDailyRankingUpdate() {
     log.info("갱신 실행");
     updateDailyRanking();

--- a/src/main/java/com/umc7th/a1grade/domain/user/dto/AllGradeResponseDto.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/dto/AllGradeResponseDto.java
@@ -3,15 +3,13 @@ package com.umc7th.a1grade.domain.user.dto;
 import java.math.BigDecimal;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
+import lombok.*;
 
 @Data
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 @Schema(title = "AllGradeResponseDto : 3순위 사용자 조회 응답 DTO")
 public class AllGradeResponseDto {
   @Schema(description = "사용자 순위", example = "1")

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
@@ -36,10 +36,11 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
           + "    HAVING COUNT(DISTINCT ql.userQuestion.id) >= 10)")
   List<User> findUserWithCorrectAnswers();
 
-  @Query("SELECT u FROM User u " +
-          "LEFT JOIN FETCH u.userCharacters " +
-          "WHERE u.id IN " +
-          "(SELECT DISTINCT ql.user.id FROM QuestionLog ql WHERE ql.submissionTime BETWEEN :start AND :end)")
-  List<User> findUsersWhoSolvedQuestions(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
-
+  @Query(
+      "SELECT u FROM User u "
+          + "LEFT JOIN FETCH u.userCharacters "
+          + "WHERE u.id IN "
+          + "(SELECT DISTINCT ql.user.id FROM QuestionLog ql WHERE ql.submissionTime BETWEEN :start AND :end)")
+  List<User> findUsersWhoSolvedQuestions(
+      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/com/umc7th/a1grade/domain/user/repository/UserJpaRepository.java
@@ -36,10 +36,10 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
           + "    HAVING COUNT(DISTINCT ql.userQuestion.id) >= 10)")
   List<User> findUserWithCorrectAnswers();
 
-  @Query(
-      "SELECT DISTINCT ql.user FROM QuestionLog ql "
-          + "WHERE ql.submissionTime "
-          + "BETWEEN :start AND :end")
-  List<User> findUsersWhoSolvedQuestions(
-      @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+  @Query("SELECT u FROM User u " +
+          "LEFT JOIN FETCH u.userCharacters " +
+          "WHERE u.id IN " +
+          "(SELECT DISTINCT ql.user.id FROM QuestionLog ql WHERE ql.submissionTime BETWEEN :start AND :end)")
+  List<User> findUsersWhoSolvedQuestions(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
 }


### PR DESCRIPTION
## 🐛 주요 해결된 이슈
 데이터를 적절히 넣었음에도 랭킹 조회가 되지 않는 버그 발생
- `LazyInitializationException` 발생 해결 (`user.getUserCharacters()` 접근 시 세션 종료 문제) 
- `IllegalStateException: For queries with named parameters........~~` 오류 해결  
- Redis에서 `AllGradeResponseDto` 역직렬화 실패 해결  

## 📌 작업 내용 및 특이사항
- `countTotalAttempts()` JPA 쿼리에 `@Param` 추가하여 Named Parameter 오류 해결
- `findUsersWhoSolvedQuestions()`에서 `JOIN FETCH` 추가하여 `userCharacters` 미리 로딩 
- `AllGradeResponseDto` 에 `@NoArgsConstructor` 추가하여 JSON 변환이 되도록 수정

로컬에서 스케줄러 실행 주기를 줄여 테스트한 결과, 의도한 대로 정상적으로 동작함을 확인하였습니다.
